### PR TITLE
Filter list items according to urgency

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -205,7 +205,7 @@ nav {
   animation-delay: 0.4s;
 }
 
-.list__item {
+li {
   position: relative;
   margin: 0px;
   margin-bottom: 15px;
@@ -262,4 +262,20 @@ nav {
   grid-row-gap: 20px;
   text-align: center;
   justify-content: center;
+}
+
+.soon {
+  background-color: red;
+}
+
+.kind-of-soon {
+  background-color: pink;
+}
+
+.not-soon {
+  background-color: green;
+}
+
+.inactive {
+  background-color: grey;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -264,6 +264,7 @@ li {
   justify-content: center;
 }
 
+/*ITEM STATE*/
 .soon {
   background-color: red;
 }
@@ -278,4 +279,15 @@ li {
 
 .inactive {
   background-color: grey;
+}
+
+.flex-row {
+  display: flex;
+  margin-bottom: 0.5rem;
+}
+
+.color-box {
+  height: 1rem;
+  width: 1rem;
+  margin-right: 1rem;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -288,6 +288,6 @@ li {
 
 .color-box {
   height: 1rem;
-  width: 1rem;
+  min-width: 1rem;
   margin-right: 1rem;
 }

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -3,7 +3,7 @@ import calculateEstimate from '../lib/estimates';
 
 import { db } from '../lib/firebase';
 
-const Checkbox = ({ item, shoppingList }) => {
+const Checkbox = ({ item, ariaLabel, shoppingList }) => {
   const [checked, setChecked] = useState(false);
 
   const { name, id, daysLeftForNextPurchase, lastPurchasedDate } = item;
@@ -54,7 +54,7 @@ const Checkbox = ({ item, shoppingList }) => {
   };
 
   return (
-    <>
+    <div aria-label={ariaLabel}>
       <input
         type="checkbox"
         name={name}
@@ -68,7 +68,7 @@ const Checkbox = ({ item, shoppingList }) => {
       <label htmlFor={name} className="list__item__label">
         {name}
       </label>
-    </>
+    </div>
   );
 };
 

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -3,6 +3,8 @@ import Checkbox from '../components/Checkbox';
 
 const ListItem = ({ index, item, shoppingList }) => (
   <li className={index}>
+    {' '}
+    aria-label={index}
     <Checkbox item={item} shoppingList={shoppingList} />
   </li>
 );

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -3,7 +3,6 @@ import Checkbox from '../components/Checkbox';
 
 const ListItem = ({ index, item, shoppingList }) => (
   <li className={index} aria-label={index}>
-    {' '}
     <Checkbox item={item} shoppingList={shoppingList} />
   </li>
 );

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import Checkbox from '../components/Checkbox';
 
-const ListItem = ({ index, item, shoppingList }) => (
-  <li className={index} aria-label={index}>
-    <Checkbox item={item} shoppingList={shoppingList} />
+const ListItem = ({ index, ariaLabel, item, shoppingList }) => (
+  <li className={index}>
+    <Checkbox item={item} ariaLabel={ariaLabel} shoppingList={shoppingList} />
   </li>
 );
 

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import Checkbox from '../components/Checkbox';
 
-const ListItem = ({ item, shoppingList }) => (
-  <li className="list__item">
+const ListItem = ({ index, item, shoppingList }) => (
+  <li className={index}>
     <Checkbox item={item} shoppingList={shoppingList} />
   </li>
 );

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -2,9 +2,8 @@ import React from 'react';
 import Checkbox from '../components/Checkbox';
 
 const ListItem = ({ index, item, shoppingList }) => (
-  <li className={index}>
+  <li className={index} aria-label={index}>
     {' '}
-    aria-label={index}
     <Checkbox item={item} shoppingList={shoppingList} />
   </li>
 );

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -36,7 +36,7 @@ const ListView = ({ shoppingList, loading, error }) => {
     //sort items according to days left till next purchase
     //if items have same number of days left, filter alphabetically
     //used localeCompare to sort without consideration for case
-    const filterUrgency = () => {
+    const sortByUrgency = () => {
       setSortedList(
         shoppingList[0].items.sort(
           (a, b) =>
@@ -48,7 +48,7 @@ const ListView = ({ shoppingList, loading, error }) => {
 
     if (loading === false && shoppingList[0] !== undefined) {
       setLength(shoppingList[0].items.length);
-      filterUrgency();
+      sortByUrgency();
     }
 
     if (length >= 1) {
@@ -93,12 +93,12 @@ const ListView = ({ shoppingList, loading, error }) => {
               const searchResult = item.name.includes(
                 value.toLowerCase().trim(),
               );
-              //pass parameters to checkIndex function
-              const lastPurchase = item.LastPurchasedDate;
-              const nextPurchase = item.daysLeftForNextPurchase;
-              const timesPurchased = item.numberOfPurchases;
               //check urgency index of item
-              checkIndex(lastPurchase, nextPurchase, timesPurchased);
+              checkIndex(
+                item.lastPurchasedDate,
+                item.daysLeftForNextPurchase,
+                item.numberOfPurchases,
+              );
 
               return (
                 searchResult && (

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -19,29 +19,44 @@ const ListView = ({ shoppingList, loading, error }) => {
   useEffect(() => {
     const filterUrgency = () => {
       //filters items according to days left till next purchase
-      //still need to add number of purchases to criteria (for inactive items)
-      //Haven't filtered and sorted inactive items.
       const soonItems = shoppingList[0].items.filter(
-        (item) => item.daysLeftForNextPurchase < 7,
+        (item) =>
+          item.daysLeftForNextPurchase < 7 && item.numberOfPurchases > 1,
       );
       const kindOfSoonItems = shoppingList[0].items.filter(
         (item) =>
           item.daysLeftForNextPurchase >= 7 &&
-          item.daysLeftForNextPurchase < 30,
+          item.daysLeftForNextPurchase < 30 &&
+          item.numberOfPurchases > 1,
       );
       const notSoonItems = shoppingList[0].items.filter(
-        (item) => item.daysLeftForNextPurchase > 30,
+        (item) =>
+          item.daysLeftForNextPurchase > 30 && item.numberOfPurchases > 1,
+      );
+      const inactiveItems = shoppingList[0].items.filter(
+        (item) =>
+          item.numberOfPurchases <= 1 ||
+          item.LastPurchasedDate >= 2 * item.daysLeftForNextPurchase,
       );
 
-      //sorted items alphabetically
+      //sort items according to date for next purchase or alphabetically
       //used localeCompare to sort without consideration for case
-      //The ACs say to sort according to date for next purchase though, and then
-      //items with same date should be sorted alphabetically. Need to fix.
       setSoonArr(soonItems.sort((a, b) => a.name.localeCompare(b.name)));
       setKindOfSoonArr(
-        kindOfSoonItems.sort((a, b) => a.name.localeCompare(b.name)),
+        kindOfSoonItems.sort(
+          (a, b) =>
+            a.daysLeftForNextPurchase - b.daysLeftForNextPurchase ||
+            a.name.localeCompare(b.name),
+        ),
       );
       setNotSoonArr(notSoonItems.sort((a, b) => a.name.localeCompare(b.name)));
+      setInactiveArr(
+        inactiveItems.sort(
+          (a, b) =>
+            a.daysLeftForNextPurchase - b.daysLeftForNextPurchase ||
+            a.name.localeCompare(b.name),
+        ),
+      );
     };
 
     if (loading === false && shoppingList[0] !== undefined) {

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -9,7 +9,7 @@ const ListView = ({ shoppingList, loading, error }) => {
   const [value, setValue] = useState('');
   const [sortedList, setSortedList] = useState([]);
   //indicator for urgency status of item
-  let purchaseIndex;
+  let purchaseIndex, ariaLabel;
 
   const handleChange = (e) => setValue(e.target.value);
 
@@ -26,12 +26,16 @@ const ListView = ({ shoppingList, loading, error }) => {
       interval >= 2 * nextPurchase * dayToMilliseconds
     ) {
       purchaseIndex = 'inactive';
+      ariaLabel = 'inactive';
     } else if (nextPurchase < 7) {
       purchaseIndex = 'soon';
+      ariaLabel = 'next purchase: soon';
     } else if (nextPurchase < 30) {
       purchaseIndex = 'kind-of-soon';
+      ariaLabel = 'next purchase: kind of soon';
     } else {
       purchaseIndex = 'not-soon';
+      ariaLabel = 'next purchase: not soon';
     }
   };
 
@@ -108,30 +112,35 @@ const ListView = ({ shoppingList, loading, error }) => {
                   <ListItem
                     key={item.id}
                     item={item}
-                    //index prop assigns className and aria-label to item
-                    index={purchaseIndex}
                     shoppingList={shoppingList}
+                    //pass props for className and aria-label to item
+                    index={purchaseIndex}
+                    ariaLabel={ariaLabel}
                   />
                 )
               );
             })}
           </ul>
-          <div className="legend" aria-hidden="true">
+
+          <div className="legend">
             <h2>Legend</h2>
             <div className="flex-row">
-              <div className="color-box soon"></div>
+              <div className="color-box soon" aria-label="soon"></div>
               <p>Less than 7 days till next purchase</p>
             </div>
             <div className="flex-row">
-              <div className="color-box kind-of-soon"></div>
+              <div
+                className="color-box kind-of-soon"
+                aria-label="kind of soon"
+              ></div>
               <p>7-30 days till next purchase</p>
             </div>
             <div className="flex-row">
-              <div className="color-box not-soon"></div>
+              <div className="color-box not-soon" aria-label="not soon"></div>
               <p>More than 30 days till next purchase</p>
             </div>
             <div className="flex-row">
-              <div className="color-box inactive"></div>
+              <div className="color-box inactive" aria-label="inactive"></div>
               <p>
                 Item has been purchased less than twice, or estimated purchase
                 time has elapsed significantly.

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -8,15 +8,19 @@ const ListView = ({ shoppingList, loading, error }) => {
   const [length, setLength] = useState(0);
   const [value, setValue] = useState('');
 
+  //arrays for items filtered according to urgency
   const [soonArr, setSoonArr] = useState([]);
   const [kindOfSoonArr, setKindOfSoonArr] = useState([]);
   const [notSoonArr, setNotSoonArr] = useState([]);
-  //const [inactiveArr, setInactiveArr] = useState([]);
+  const [inactiveArr, setInactiveArr] = useState([]);
 
   const handleChange = (e) => setValue(e.target.value);
 
   useEffect(() => {
     const filterUrgency = () => {
+      //filters items according to days left till next purchase
+      //still need to add number of purchases to criteria (for inactive items)
+      //Haven't filtered and sorted inactive items.
       const soonItems = shoppingList[0].items.filter(
         (item) => item.daysLeftForNextPurchase < 7,
       );
@@ -29,12 +33,15 @@ const ListView = ({ shoppingList, loading, error }) => {
         (item) => item.daysLeftForNextPurchase > 30,
       );
 
+      //sorted items alphabetically
+      //used localeCompare to sort without consideration for case
+      //The ACs say to sort according to date for next purchase though, and then
+      //items with same date should be sorted alphabetically. Need to fix.
       setSoonArr(soonItems.sort((a, b) => a.name.localeCompare(b.name)));
       setKindOfSoonArr(
         kindOfSoonItems.sort((a, b) => a.name.localeCompare(b.name)),
       );
       setNotSoonArr(notSoonItems.sort((a, b) => a.name.localeCompare(b.name)));
-      console.log(shoppingList[0]);
     };
 
     if (loading === false && shoppingList[0] !== undefined) {
@@ -81,6 +88,7 @@ const ListView = ({ shoppingList, loading, error }) => {
 
           <ul className="list">
             {soonArr.length && (
+              //maps items in each array into separate divs so they are displayed together
               <div className="container__soon">
                 {soonArr.map((item) => {
                   const searchResult = item.name.includes(
@@ -92,6 +100,8 @@ const ListView = ({ shoppingList, loading, error }) => {
                       <ListItem
                         key={item.id}
                         item={item}
+                        //passes the state of urgency to ListItem as a prop for className and aria-label
+                        //in CSS, added styling for class names (background colour)
                         index="soon"
                         shoppingList={shoppingList}
                       />
@@ -142,29 +152,27 @@ const ListView = ({ shoppingList, loading, error }) => {
                 })}
               </div>
             )}
+            {inactiveArr.length && (
+              <div className="container__inactive">
+                {inactiveArr.map((item) => {
+                  const searchResult = item.name.includes(
+                    value.toLowerCase().trim(),
+                  );
 
-            <div className="container__inactive"></div>
+                  return (
+                    searchResult && (
+                      <ListItem
+                        key={item.id}
+                        item={item}
+                        index="inactive"
+                        shoppingList={shoppingList}
+                      />
+                    )
+                  );
+                })}
+              </div>
+            )}
           </ul>
-          {/*
-              
-              shoppingList[0].items.map((item) => {
-                const searchResult = item.name.includes(
-                  value.toLowerCase().trim(),
-                );
-                const nextPurchase = item.daysLeftForNextPurchase;
-                checkIndex(nextPurchase);
-
-                return (
-                  searchResult && (
-                    <ListItem
-                      key={item.id}
-                      item={item}
-                      index={purchaseIndex}
-                      shoppingList={shoppingList}
-                    />
-                  )
-                );
-              })} */}
         </main>
       )}
     </>

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -113,6 +113,28 @@ const ListView = ({ shoppingList, loading, error }) => {
               );
             })}
           </ul>
+          <div className="legend" aria-hidden="true">
+            <h2>Legend</h2>
+            <div className="flex-row">
+              <div className="color-box soon"></div>
+              <p>Less than 7 days till next purchase</p>
+            </div>
+            <div className="flex-row">
+              <div className="color-box kind-of-soon"></div>
+              <p>7-30 days till next purchase</p>
+            </div>
+            <div className="flex-row">
+              <div className="color-box not-soon"></div>
+              <p>More than 30 days till next purchase</p>
+            </div>
+            <div className="flex-row">
+              <div className="color-box inactive"></div>
+              <p>
+                Item has been purchased less than twice, or estimated purchase
+                time has elapsed significantly.
+              </p>
+            </div>
+          </div>
         </main>
       )}
     </>

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -16,10 +16,15 @@ const ListView = ({ shoppingList, loading, error }) => {
   //assign value to purchaseIndex based on these parameters
   const checkIndex = (lastPurchase, nextPurchase, timesPurchased) => {
     //check interval between current date and date of last purchase
+    const interval = new Date().getTime() - lastPurchase;
+    //one day converted to milliseconds
+    const dayToMilliseconds = 86400000;
     //set index as inactive if item has been purchased only once or less
     //or if interval is >= 2 times the projected estimate
-    const interval = new Date().getTime() - lastPurchase;
-    if (timesPurchased <= 1 || interval >= 2 * nextPurchase * 86400000) {
+    if (
+      timesPurchased <= 1 ||
+      interval >= 2 * nextPurchase * dayToMilliseconds
+    ) {
       purchaseIndex = 'inactive';
     } else if (nextPurchase < 7) {
       purchaseIndex = 'soon';
@@ -29,8 +34,6 @@ const ListView = ({ shoppingList, loading, error }) => {
       purchaseIndex = 'not-soon';
     }
   };
-
-  //todays date - lastpurchase >= 2*nextpurchase
 
   useEffect(() => {
     //sort items according to days left till next purchase

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -7,25 +7,39 @@ const ListView = ({ shoppingList, loading, error }) => {
   const [shoppingListEmpty, setShoppingListEmpty] = useState(true);
   const [length, setLength] = useState(0);
   const [value, setValue] = useState('');
-  let purchaseIndex;
+
+  const [soonArr, setSoonArr] = useState([]);
+  const [kindOfSoonArr, setKindOfSoonArr] = useState([]);
+  const [notSoonArr, setNotSoonArr] = useState([]);
+  //const [inactiveArr, setInactiveArr] = useState([]);
 
   const handleChange = (e) => setValue(e.target.value);
 
-  const checkIndex = (nextPurchase) => {
-    if (nextPurchase < 7) {
-      purchaseIndex = 'soon';
-    } else if (nextPurchase < 30) {
-      purchaseIndex = 'kind-of-soon';
-    } else if (nextPurchase > 30) {
-      purchaseIndex = 'not-soon';
-    } else {
-      purchaseIndex = 'inactive';
-    }
-  };
-
   useEffect(() => {
+    const filterUrgency = () => {
+      const soonItems = shoppingList[0].items.filter(
+        (item) => item.daysLeftForNextPurchase < 7,
+      );
+      const kindOfSoonItems = shoppingList[0].items.filter(
+        (item) =>
+          item.daysLeftForNextPurchase >= 7 &&
+          item.daysLeftForNextPurchase < 30,
+      );
+      const notSoonItems = shoppingList[0].items.filter(
+        (item) => item.daysLeftForNextPurchase > 30,
+      );
+
+      setSoonArr(soonItems.sort((a, b) => a.name.localeCompare(b.name)));
+      setKindOfSoonArr(
+        kindOfSoonItems.sort((a, b) => a.name.localeCompare(b.name)),
+      );
+      setNotSoonArr(notSoonItems.sort((a, b) => a.name.localeCompare(b.name)));
+      console.log(shoppingList[0]);
+    };
+
     if (loading === false && shoppingList[0] !== undefined) {
       setLength(shoppingList[0].items.length);
+      filterUrgency();
     }
 
     if (length >= 1) {
@@ -52,7 +66,7 @@ const ListView = ({ shoppingList, loading, error }) => {
           <div></div>
         </div>
       )}
-      {!loading && (
+      {shoppingList && shoppingList[0] && (
         <main>
           <form className="search-box">
             <input
@@ -66,8 +80,73 @@ const ListView = ({ shoppingList, loading, error }) => {
           </form>
 
           <ul className="list">
-            {shoppingList &&
-              shoppingList[0] &&
+            {soonArr.length && (
+              <div className="container__soon">
+                {soonArr.map((item) => {
+                  const searchResult = item.name.includes(
+                    value.toLowerCase().trim(),
+                  );
+
+                  return (
+                    searchResult && (
+                      <ListItem
+                        key={item.id}
+                        item={item}
+                        index="soon"
+                        shoppingList={shoppingList}
+                      />
+                    )
+                  );
+                })}
+              </div>
+            )}
+
+            {kindOfSoonArr.length && (
+              <div className="container__kind-of-soon">
+                {kindOfSoonArr.map((item) => {
+                  const searchResult = item.name.includes(
+                    value.toLowerCase().trim(),
+                  );
+
+                  return (
+                    searchResult && (
+                      <ListItem
+                        key={item.id}
+                        item={item}
+                        index="kind-of-soon"
+                        shoppingList={shoppingList}
+                      />
+                    )
+                  );
+                })}
+              </div>
+            )}
+
+            {notSoonArr.length && (
+              <div className="container__not-soon">
+                {notSoonArr.map((item) => {
+                  const searchResult = item.name.includes(
+                    value.toLowerCase().trim(),
+                  );
+
+                  return (
+                    searchResult && (
+                      <ListItem
+                        key={item.id}
+                        item={item}
+                        index="not-soon"
+                        shoppingList={shoppingList}
+                      />
+                    )
+                  );
+                })}
+              </div>
+            )}
+
+            <div className="container__inactive"></div>
+          </ul>
+          {/*
+              
               shoppingList[0].items.map((item) => {
                 const searchResult = item.name.includes(
                   value.toLowerCase().trim(),
@@ -85,8 +164,7 @@ const ListView = ({ shoppingList, loading, error }) => {
                     />
                   )
                 );
-              })}
-          </ul>
+              })} */}
         </main>
       )}
     </>

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -7,8 +7,21 @@ const ListView = ({ shoppingList, loading, error }) => {
   const [shoppingListEmpty, setShoppingListEmpty] = useState(true);
   const [length, setLength] = useState(0);
   const [value, setValue] = useState('');
+  let purchaseIndex;
 
   const handleChange = (e) => setValue(e.target.value);
+
+  const checkIndex = (nextPurchase) => {
+    if (nextPurchase < 7) {
+      purchaseIndex = 'soon';
+    } else if (nextPurchase < 30) {
+      purchaseIndex = 'kind-of-soon';
+    } else if (nextPurchase > 30) {
+      purchaseIndex = 'not-soon';
+    } else {
+      purchaseIndex = 'inactive';
+    }
+  };
 
   useEffect(() => {
     if (loading === false && shoppingList[0] !== undefined) {
@@ -59,11 +72,15 @@ const ListView = ({ shoppingList, loading, error }) => {
                 const searchResult = item.name.includes(
                   value.toLowerCase().trim(),
                 );
+                const nextPurchase = item.daysLeftForNextPurchase;
+                checkIndex(nextPurchase);
+
                 return (
                   searchResult && (
                     <ListItem
                       key={item.id}
                       item={item}
+                      index={purchaseIndex}
                       shoppingList={shoppingList}
                     />
                   )

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -15,7 +15,11 @@ const ListView = ({ shoppingList, loading, error }) => {
 
   //assign value to purchaseIndex based on these parameters
   const checkIndex = (lastPurchase, nextPurchase, timesPurchased) => {
-    if (timesPurchased <= 1 || lastPurchase >= 2 * nextPurchase) {
+    //check interval between current date and date of last purchase
+    //set index as inactive if item has been purchased only once or less
+    //or if interval is >= 2 times the projected estimate
+    const interval = new Date().getTime() - lastPurchase;
+    if (timesPurchased <= 1 || interval >= 2 * nextPurchase * 86400000) {
       purchaseIndex = 'inactive';
     } else if (nextPurchase < 7) {
       purchaseIndex = 'soon';
@@ -25,6 +29,8 @@ const ListView = ({ shoppingList, loading, error }) => {
       purchaseIndex = 'not-soon';
     }
   };
+
+  //todays date - lastpurchase >= 2*nextpurchase
 
   useEffect(() => {
     //sort items according to days left till next purchase
@@ -92,12 +98,7 @@ const ListView = ({ shoppingList, loading, error }) => {
               const nextPurchase = item.daysLeftForNextPurchase;
               const timesPurchased = item.numberOfPurchases;
               //check urgency index of item
-              checkIndex(
-                lastPurchase,
-                nextPurchase,
-                timesPurchased,
-                purchaseIndex,
-              );
+              checkIndex(lastPurchase, nextPurchase, timesPurchased);
 
               return (
                 searchResult && (

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -23,9 +23,9 @@ const ListView = ({ shoppingList, loading, error }) => {
       purchaseIndex = 'inactive';
     } else if (nextPurchase < 7) {
       purchaseIndex = 'soon';
-    } else if (nextPurchase >= 7 && nextPurchase < 30) {
+    } else if (nextPurchase < 30) {
       purchaseIndex = 'kind-of-soon';
-    } else if (nextPurchase > 30) {
+    } else {
       purchaseIndex = 'not-soon';
     }
   };


### PR DESCRIPTION
## Description
This PR displays list items according to urgency. It sorts the list items in order of days left for the next purchase (or alphabetically if items have the same number of days left) and assigns classNames to the items corresponding with the possible states in the Acceptance Criteria.
The aesthetic leaves a lot to be desired haha, but hopefully that'll be sorted with next week's issue. 

## Related Issue
Closes #13 

## Acceptance Criteria
- [x] Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
- [x] Items should be sorted by the estimated number of days until next purchase
- [x] Items with the same number of estimated days until next purchase should be sorted alphabetically
- [x] Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->


## Testing Steps / QA Criteria
1. From your terminal pull down this branch with `git pull cz-io-sort-list-items` and check that branch out with `git checkout  cz-io-sort-list-items`.
2. Then `npm start` to launch the app.
3. Create a new shopping list or join with an existing token.
4. If there are no items on your list, add item(s) in AddView. Navigate back to ListView and:
5. Ensure that:
     - Items have different background colours according to how soon the item is expected to be bought again.
     - Items are sorted by the estimated number of days until next purchase
     - Items with the same number of estimated days until next purchase are sorted alphabetically
     - Items in the different states have corresponding aria labels.
6. The possible states are:
    * Need to buy soon (fewer than 7 days)
    * Need to buy kind of soon (between 7 & 30 days)
    * Need to buy not soon (more than 30 days)
    * Inactive (when there’s only 1 purchase in the database or the purchase is really out of date [the time that has elapsed since the last purchase is 2x what was estimated]) 
    Fiddle with the dates and number of purchases in the database to test if everything works as expected.



